### PR TITLE
Fix run: fix spotbugs XML parsing

### DIFF
--- a/dusty/data_model/spotbugs/parser.py
+++ b/dusty/data_model/spotbugs/parser.py
@@ -44,8 +44,12 @@ class SpotbugsParser(object):
             details = data.find(f'.//BugPattern[@type="{issue_type}"]')
             for i, element in enumerate(item.findall('Method')):
                 steps_to_reproduce += f"Classname: {classname}\t" \
-                                      f"{element.find('Message').text}\t" \
-                                      f"{sanitize(item.findall('SourceLine')[i].find('Message').text)}\n\n"
+                                      f"{element.find('Message').text}\t"
+                try:
+                    steps_to_reproduce += \
+                                      f"{sanitize(item.findall('SourceLine')[i].find('Message').text)}"
+                finally:
+                    steps_to_reproduce += "\n\n"
 
             if details:
                 description += f'\n\n Details: {details.find("Details").text}'

--- a/dusty/data_model/spotbugs/parser.py
+++ b/dusty/data_model/spotbugs/parser.py
@@ -48,6 +48,8 @@ class SpotbugsParser(object):
                 try:
                     steps_to_reproduce += \
                                       f"{sanitize(item.findall('SourceLine')[i].find('Message').text)}"
+                except:
+                    pass
                 finally:
                     steps_to_reproduce += "\n\n"
 


### PR DESCRIPTION
Spotbugs parsing seems to be broken by c5cbbdd1ace7538dfcc94a29ad8a528ecb4fbff0
This change catches exception which allows spotbugs parser to continue.
Still, it may be needed to rework spotbugs parsing and reported information.