### PR TITLE
Fix empty HTML report creation when Jira ticket creation fails

### DIFF
--- a/dusty/utils.py
+++ b/dusty/utils.py
@@ -20,6 +20,7 @@ import threading
 from subprocess import Popen, PIPE
 from datetime import datetime
 from dusty import constants as c
+from traceback import format_exc
 
 
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
@@ -160,8 +161,13 @@ def common_post_processing(config, result, tool_name, need_other_results=False):
     other_results = []
     filtered_result = process_false_positives(result, config)
     filtered_result = process_min_priority(config, filtered_result, other_results=other_results)
-    report_to_rp(config, filtered_result, tool_name)
-    report_to_jira(config, filtered_result)
+    try:
+        report_to_rp(config, filtered_result, tool_name)
+        report_to_jira(config, filtered_result)
+    except:
+        print("Failed to report issues in Jira/RP")
+        if os.environ.get("debug", False):
+            print(format_exc())
     if need_other_results:
         return filtered_result, other_results
     return filtered_result


### PR DESCRIPTION
Bug fix: if Jira ticket creation fails, dusty ignores findings and report is empty.