### PR TITLE
Fix created Jira tickets collection for email reporting

### DIFF
--- a/dusty/run.py
+++ b/dusty/run.py
@@ -244,6 +244,10 @@ def main():
             try:
                 tool_name, result = getattr(DustyWrapper, key)(config)
                 results, other_results = common_post_processing(config, result, tool_name, need_other_results=True)
+                if default_config.get('jira_service', None) and config.get('jira_service', None):
+                    default_config['jira_service'].created_jira_tickets.extend(
+                        config.get('jira_service').get_created_tickets()
+                    )
             except:
                 print("Exception during %s Scanning" % key)
                 if os.environ.get("debug", False):


### PR DESCRIPTION
Currently dusty is using deepcopy(default_config) to get scanner local config. At the same time default_config contains JiraWrapper instance in "jira_service". It seems every scanner gets own JiraWrapper instance, which leads to empty created_jira_tickets during email text preparation.

This fix merges all created jira tickets.