### PR TITLE
Added support for custom per-scanner final Jira re-mapping

### DIFF
--- a/dusty/data_model/canonical_model.py
+++ b/dusty/data_model/canonical_model.py
@@ -176,8 +176,11 @@ class DefaultModel(object):
         tc.add_error_info(message=message, error_type=self.finding['severity'])
         return tc
 
-    def jira(self, jira_client):
-        issue, created = jira_client.create_issue(self.finding["title"], c.SEVERITY_MAPPING[self.finding['severity']],
+    def jira(self, jira_client, priority_mapping=None):
+        priority = c.SEVERITY_MAPPING[self.finding['severity']]
+        if priority_mapping and priority in priority_mapping:
+            priority = priority_mapping[priority]
+        issue, created = jira_client.create_issue(self.finding["title"], priority,
                                  self.__str__(), self.get_hash_code(),
                                  additional_labels=[self.finding["tool"], self.scan_type, self.finding["severity"]])
         return issue, created

--- a/dusty/utils.py
+++ b/dusty/utils.py
@@ -42,7 +42,7 @@ def report_to_jira(config, result):
         config.get('jira_service').connect()
         print(config.get('jira_service').client)
         for item in result:
-            issue, created = item.jira(config['jira_service'])
+            issue, created = item.jira(config['jira_service'], config.get('jira_mapping', None))
             if created:
                 print(issue.key)
     elif config.get('jira_service') and not config.get('jira_service').valid:


### PR DESCRIPTION
Some projects are using non-default priority levels in Jira (e.g. "Very High" instead of "Critical"). Currently dusty only supports default values, which blocks us from enabling Jira integration during on-boarding on some of the projects.

This change adds ability to manually remap final priority level in project config (until dusty jira code will be refactored).