### PR TITLE
SAST: also return other_results so it can be shown in HTML report

### DIFF
--- a/dusty/run.py
+++ b/dusty/run.py
@@ -352,6 +352,8 @@ def main():
             attr_name = config[key] if 'language' in key else key
             try:
                 results = getattr(SastyWrapper, attr_name)(config)
+                if isinstance(results, tuple):
+                    results, other_results = results
             except BaseException as e:
                 logging.error("Exception during %s Scanning" % attr_name)
                 global_errors[attr_name] = str(e)

--- a/dusty/sastyWrapper.py
+++ b/dusty/sastyWrapper.py
@@ -45,7 +45,7 @@ class SastyWrapper(object):
         results = run_in_parallel(params)
         for result in results:
             all_results.extend(result)
-        filtered_result = common_post_processing(config, all_results, language)
+        filtered_result = common_post_processing(config, all_results, language, need_other_results=True)
         return filtered_result
 
     @staticmethod
@@ -89,7 +89,7 @@ class SastyWrapper(object):
                    f"-o /tmp/brakeman.json " + SastyWrapper.get_code_path(config)
         execute(exec_cmd, cwd=SastyWrapper.get_code_path(config))
         result = BrakemanParser("/tmp/brakeman.json", "brakeman").items
-        filtered_result = common_post_processing(config, result, "brakeman")
+        filtered_result = common_post_processing(config, result, "brakeman", need_other_results=True)
         return filtered_result
 
     @staticmethod


### PR DESCRIPTION
Currently "Other findings" are only returned for DAST scans.
With the integration of gosec scanner we have a need to filter SAST results too.
This PR enables other_results separation for some of SAST scanners too.